### PR TITLE
Add fire-and-forget error handling with TaskExtensions (fixes #12)

### DIFF
--- a/src/PushToTalk.App/DictationService.cs
+++ b/src/PushToTalk.App/DictationService.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging;
 using Olbrasoft.PushToTalk.App.Services;
 using Olbrasoft.PushToTalk.Audio;
+using Olbrasoft.PushToTalk.Core.Extensions;
 using Olbrasoft.PushToTalk.Speech;
 using Olbrasoft.PushToTalk.TextInput;
 
@@ -123,19 +124,19 @@ public class DictationService : IDisposable, IAsyncDisposable
         if (capsLockOn && _state == DictationState.Idle)
         {
             _logger.LogInformation("{TriggerKey} pressed, CapsLock ON - starting dictation", _triggerKey);
-            _ = Task.Run(() => StartDictationAsync());
+            Task.Run(() => StartDictationAsync()).FireAndForget(_logger, "StartDictation");
         }
         // CapsLock OFF + Recording → stop recording and transcribe
         else if (!capsLockOn && _state == DictationState.Recording)
         {
             _logger.LogInformation("{TriggerKey} pressed, CapsLock OFF - stopping dictation", _triggerKey);
-            _ = Task.Run(() => StopDictationAsync());
+            Task.Run(() => StopDictationAsync()).FireAndForget(_logger, "StopDictation");
         }
         // CapsLock ON + Recording → user toggled again, stop (emergency stop)
         else if (capsLockOn && _state == DictationState.Recording)
         {
             _logger.LogWarning("CapsLock toggled ON while recording - emergency stop");
-            _ = Task.Run(() => StopDictationAsync());
+            Task.Run(() => StopDictationAsync()).FireAndForget(_logger, "StopDictation");
         }
         // If Transcribing, ignore the trigger key press (but cancel key is handled above)
     }

--- a/src/PushToTalk.App/Hubs/DictationHub.cs
+++ b/src/PushToTalk.App/Hubs/DictationHub.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Logging;
+using Olbrasoft.PushToTalk.Core.Extensions;
 using Olbrasoft.PushToTalk.TextInput;
 
 namespace Olbrasoft.PushToTalk.App.Hubs;
@@ -58,7 +59,7 @@ public class DictationHub : Hub
         {
             // Fire-and-forget: don't await so the hub method returns immediately
             // This allows the client to call CancelTranscription while transcription is running
-            _ = Task.Run(() => _dictationService.StopDictationAsync());
+            Task.Run(() => _dictationService.StopDictationAsync()).FireAndForget(_logger, "StopDictation");
         }
         return Task.CompletedTask;
     }
@@ -71,13 +72,13 @@ public class DictationHub : Hub
         if (_dictationService.State == DictationState.Idle)
         {
             // StartDictationAsync is already non-blocking
-            _ = Task.Run(() => _dictationService.StartDictationAsync());
+            Task.Run(() => _dictationService.StartDictationAsync()).FireAndForget(_logger, "StartDictation");
         }
         else if (_dictationService.State == DictationState.Recording)
         {
             // Fire-and-forget: don't await so the hub method returns immediately
             // This allows the client to call CancelTranscription while transcription is running
-            _ = Task.Run(() => _dictationService.StopDictationAsync());
+            Task.Run(() => _dictationService.StopDictationAsync()).FireAndForget(_logger, "StopDictation");
         }
         return Task.CompletedTask;
     }
@@ -100,7 +101,7 @@ public class DictationHub : Hub
         _logger.LogInformation("SendEnter called from client {ConnectionId}", Context.ConnectionId);
         // Fire-and-forget so the hub returns immediately
         // Note: dotool uses "enter" (lowercase), not "Return"
-        _ = Task.Run(() => _textTyper.SendKeyAsync("enter"));
+        Task.Run(() => _textTyper.SendKeyAsync("enter")).FireAndForget(_logger, "SendEnter");
         return Task.CompletedTask;
     }
 }

--- a/src/PushToTalk.App/Program.cs
+++ b/src/PushToTalk.App/Program.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
 using Olbrasoft.PushToTalk.App;
 using Olbrasoft.PushToTalk.App.Hubs;
+using Olbrasoft.PushToTalk.Core.Extensions;
 using Olbrasoft.PushToTalk.TextInput;
 
 // Single instance check
@@ -278,7 +279,7 @@ try
     }
 
     // Start web server in background
-    _ = Task.Run(async () =>
+    Task.Run(async () =>
     {
         try
         {
@@ -290,13 +291,13 @@ try
         {
             // Normal shutdown
         }
-    });
+    }).FireAndForget(logger, "WebServer");
 
     Console.WriteLine($"Web server started on http://localhost:{webPort}");
     Console.WriteLine($"Remote control: http://localhost:{webPort}/remote.html");
 
     // Start keyboard monitoring in background
-    _ = Task.Run(async () =>
+    Task.Run(async () =>
     {
         try
         {
@@ -310,7 +311,7 @@ try
         {
             logger.LogError(ex, "Keyboard monitoring failed");
         }
-    });
+    }).FireAndForget(logger, "KeyboardMonitoring");
 
     var triggerKey = options.GetTriggerKeyCode();
     Console.WriteLine($"Keyboard monitoring started ({triggerKey} to trigger)");

--- a/src/PushToTalk.App/TrayIcon.cs
+++ b/src/PushToTalk.App/TrayIcon.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using Olbrasoft.PushToTalk.Core.Extensions;
 using Olbrasoft.PushToTalk.Interop;
 
 namespace Olbrasoft.PushToTalk.App;
@@ -195,7 +196,7 @@ public class TrayIcon : IDisposable
         _startCallback = (widget, data) =>
         {
             _logger.LogInformation("Start Dictation clicked");
-            _ = Task.Run(() => _dictationService.StartDictationAsync());
+            Task.Run(() => _dictationService.StartDictationAsync()).FireAndForget(_logger, "StartDictation");
         };
         GObject.g_signal_connect_data(_startItem, "activate", _startCallback, IntPtr.Zero, IntPtr.Zero, 0);
 
@@ -207,7 +208,7 @@ public class TrayIcon : IDisposable
         _stopCallback = (widget, data) =>
         {
             _logger.LogInformation("Stop Dictation clicked");
-            _ = Task.Run(() => _dictationService.StopDictationAsync());
+            Task.Run(() => _dictationService.StopDictationAsync()).FireAndForget(_logger, "StopDictation");
         };
         GObject.g_signal_connect_data(_stopItem, "activate", _stopCallback, IntPtr.Zero, IntPtr.Zero, 0);
 

--- a/src/PushToTalk.Core/Extensions/TaskExtensions.cs
+++ b/src/PushToTalk.Core/Extensions/TaskExtensions.cs
@@ -1,0 +1,54 @@
+using Microsoft.Extensions.Logging;
+
+namespace Olbrasoft.PushToTalk.Core.Extensions;
+
+/// <summary>
+/// Extension methods for Task operations.
+/// </summary>
+public static class TaskExtensions
+{
+    /// <summary>
+    /// Executes a task without awaiting, but ensures exceptions are logged.
+    /// Use this instead of discarding tasks with _ = Task.Run(...).
+    /// </summary>
+    /// <param name="task">The task to execute.</param>
+    /// <param name="logger">Logger for error reporting.</param>
+    /// <param name="context">Optional context description for error messages.</param>
+    public static void FireAndForget(this Task task, ILogger logger, string? context = null)
+    {
+        task.ContinueWith(
+            t =>
+            {
+                var message = string.IsNullOrEmpty(context)
+                    ? "Unhandled exception in fire-and-forget task"
+                    : $"Unhandled exception in fire-and-forget task: {context}";
+
+                logger.LogError(t.Exception, message);
+            },
+            TaskContinuationOptions.OnlyOnFaulted);
+    }
+
+    /// <summary>
+    /// Wraps an action in Task.Run and ensures exceptions are logged.
+    /// Replaces pattern: _ = Task.Run(() => SomeMethod());
+    /// </summary>
+    /// <param name="action">The action to execute.</param>
+    /// <param name="logger">Logger for error reporting.</param>
+    /// <param name="context">Optional context description for error messages.</param>
+    public static void RunFireAndForget(Action action, ILogger logger, string? context = null)
+    {
+        Task.Run(action).FireAndForget(logger, context);
+    }
+
+    /// <summary>
+    /// Wraps an async action in Task.Run and ensures exceptions are logged.
+    /// Replaces pattern: _ = Task.Run(async () => await SomeMethodAsync());
+    /// </summary>
+    /// <param name="asyncAction">The async action to execute.</param>
+    /// <param name="logger">Logger for error reporting.</param>
+    /// <param name="context">Optional context description for error messages.</param>
+    public static void RunFireAndForget(Func<Task> asyncAction, ILogger logger, string? context = null)
+    {
+        Task.Run(asyncAction).FireAndForget(logger, context);
+    }
+}

--- a/src/PushToTalk.Core/PushToTalk.Core.csproj
+++ b/src/PushToTalk.Core/PushToTalk.Core.csproj
@@ -8,4 +8,8 @@
     <AssemblyName>Olbrasoft.PushToTalk.Core</AssemblyName>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/src/PushToTalk.Linux/MultiClickDetector.cs
+++ b/src/PushToTalk.Linux/MultiClickDetector.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using Olbrasoft.PushToTalk.Core.Extensions;
 
 namespace Olbrasoft.PushToTalk;
 
@@ -138,7 +139,7 @@ public class MultiClickDetector : IMultiClickDetector
         _timerCts = new CancellationTokenSource();
         var cts = _timerCts;
 
-        _ = Task.Run(async () =>
+        var task = Task.Run(async () =>
         {
             try
             {
@@ -161,6 +162,12 @@ public class MultiClickDetector : IMultiClickDetector
                 // Expected when cancelled by next click
             }
         });
+
+        // Add error handling if logger is available
+        if (_logger != null)
+        {
+            task.FireAndForget(_logger, $"ClickTimer_{_name}");
+        }
     }
 
     private void CancelTimer()

--- a/src/PushToTalk.Service/DictationWorker.cs
+++ b/src/PushToTalk.Service/DictationWorker.cs
@@ -1,4 +1,5 @@
 using Olbrasoft.PushToTalk.Audio;
+using Olbrasoft.PushToTalk.Core.Extensions;
 using Olbrasoft.PushToTalk.Service.Services;
 
 namespace Olbrasoft.PushToTalk.Service;
@@ -151,7 +152,7 @@ public class DictationWorker : BackgroundService, IRecordingStateProvider, IReco
         // Handle ScrollLock (ManualMute) - toggle on key release
         if (e.Key == KeyCode.ScrollLock)
         {
-            _ = Task.Run(async () => await HandleScrollLockPressedAsync());
+            Task.Run(async () => await HandleScrollLockPressedAsync()).FireAndForget(_logger, "HandleScrollLockPressed");
             return;
         }
 
@@ -181,13 +182,13 @@ public class DictationWorker : BackgroundService, IRecordingStateProvider, IReco
         {
             // CapsLock is ON and not recording - start recording
             _logger.LogInformation("CapsLock ON - starting dictation");
-            _ = Task.Run(async () => await StartRecordingAsync());
+            Task.Run(async () => await StartRecordingAsync()).FireAndForget(_logger, "StartRecording");
         }
         else if (!capsLockOn && _isRecording)
         {
             // CapsLock is OFF and recording - stop and transcribe
             _logger.LogInformation("CapsLock OFF - stopping dictation");
-            _ = Task.Run(async () => await StopRecordingAsync());
+            Task.Run(async () => await StopRecordingAsync()).FireAndForget(_logger, "StopRecording");
         }
         else
         {
@@ -283,7 +284,7 @@ public class DictationWorker : BackgroundService, IRecordingStateProvider, IReco
                     else if (result.WasHallucination)
                     {
                         // Play rejection sound for hallucination
-                        _ = Task.Run(async () => await _textOutputService.PlayRejectionSoundAsync());
+                        Task.Run(async () => await _textOutputService.PlayRejectionSoundAsync()).FireAndForget(_logger, "PlayRejectionSound");
                         await _pttNotifier.NotifyTranscriptionFailedAsync(result.ErrorMessage ?? "Whisper hallucination filtered");
                     }
                     else
@@ -297,7 +298,7 @@ public class DictationWorker : BackgroundService, IRecordingStateProvider, IReco
                     _logger.LogInformation("Transcription cancelled by user (Escape key pressed)");
 
                     // Play rejection sound for cancellation
-                    _ = Task.Run(async () => await _textOutputService.PlayRejectionSoundAsync());
+                    Task.Run(async () => await _textOutputService.PlayRejectionSoundAsync()).FireAndForget(_logger, "PlayRejectionSound");
 
                     await _pttNotifier.NotifyTranscriptionFailedAsync("Transcription cancelled");
                 }
@@ -313,7 +314,7 @@ public class DictationWorker : BackgroundService, IRecordingStateProvider, IReco
                 _logger.LogWarning("No audio data recorded");
 
                 // Play rejection sound for empty recording
-                _ = Task.Run(async () => await _textOutputService.PlayRejectionSoundAsync());
+                Task.Run(async () => await _textOutputService.PlayRejectionSoundAsync()).FireAndForget(_logger, "PlayRejectionSound");
 
                 await _pttNotifier.NotifyTranscriptionFailedAsync("No audio data recorded");
             }

--- a/tests/PushToTalk.Core.Tests/Extensions/TaskExtensionsTests.cs
+++ b/tests/PushToTalk.Core.Tests/Extensions/TaskExtensionsTests.cs
@@ -1,0 +1,187 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using Olbrasoft.PushToTalk.Core.Extensions;
+using PttTaskExtensions = Olbrasoft.PushToTalk.Core.Extensions.TaskExtensions;
+
+namespace PushToTalk.Core.Tests.Extensions;
+
+public class TaskExtensionsTests
+{
+    private readonly Mock<ILogger> _loggerMock;
+
+    public TaskExtensionsTests()
+    {
+        _loggerMock = new Mock<ILogger>();
+        _loggerMock.Setup(l => l.IsEnabled(It.IsAny<LogLevel>())).Returns(true);
+    }
+
+    [Fact]
+    public async Task FireAndForget_SuccessfulTask_DoesNotLogError()
+    {
+        // Arrange
+        var task = Task.CompletedTask;
+
+        // Act
+        task.FireAndForget(_loggerMock.Object, "TestContext");
+        await Task.Delay(50); // Allow continuation to run
+
+        // Assert
+        _loggerMock.Verify(
+            l => l.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task FireAndForget_FailedTask_LogsError()
+    {
+        // Arrange
+        var exception = new InvalidOperationException("Test exception");
+        var task = Task.FromException(exception);
+
+        // Act
+        task.FireAndForget(_loggerMock.Object, "TestContext");
+        await Task.Delay(50); // Allow continuation to run
+
+        // Assert
+        _loggerMock.Verify(
+            l => l.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("TestContext")),
+                It.IsAny<AggregateException>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task FireAndForget_WithoutContext_LogsGenericMessage()
+    {
+        // Arrange
+        var exception = new InvalidOperationException("Test exception");
+        var task = Task.FromException(exception);
+
+        // Act
+        task.FireAndForget(_loggerMock.Object);
+        await Task.Delay(50); // Allow continuation to run
+
+        // Assert
+        _loggerMock.Verify(
+            l => l.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("fire-and-forget")),
+                It.IsAny<AggregateException>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task FireAndForget_DelayedFailure_LogsErrorWhenFails()
+    {
+        // Arrange
+        var task = Task.Run(async () =>
+        {
+            await Task.Delay(10);
+            throw new InvalidOperationException("Delayed failure");
+        });
+
+        // Act
+        task.FireAndForget(_loggerMock.Object, "DelayedTask");
+        await Task.Delay(100); // Allow task to fail and continuation to run
+
+        // Assert
+        _loggerMock.Verify(
+            l => l.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("DelayedTask")),
+                It.IsAny<AggregateException>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public void RunFireAndForget_Action_ExecutesSuccessfully()
+    {
+        // Arrange
+        var executed = false;
+
+        // Act
+        PttTaskExtensions.RunFireAndForget(() => executed = true, _loggerMock.Object, "ActionTest");
+
+        // Assert - wait for execution
+        Thread.Sleep(50);
+        Assert.True(executed);
+    }
+
+    [Fact]
+    public async Task RunFireAndForget_AsyncAction_ExecutesSuccessfully()
+    {
+        // Arrange
+        var executed = false;
+
+        // Act
+        PttTaskExtensions.RunFireAndForget(async () =>
+        {
+            await Task.Delay(10);
+            executed = true;
+        }, _loggerMock.Object, "AsyncActionTest");
+
+        // Assert
+        await Task.Delay(100);
+        Assert.True(executed);
+    }
+
+    [Fact]
+    public async Task RunFireAndForget_FailingAction_LogsError()
+    {
+        // Arrange & Act
+        PttTaskExtensions.RunFireAndForget(
+            () => throw new InvalidOperationException("Action failed"),
+            _loggerMock.Object,
+            "FailingAction");
+
+        await Task.Delay(50);
+
+        // Assert
+        _loggerMock.Verify(
+            l => l.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("FailingAction")),
+                It.IsAny<AggregateException>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task RunFireAndForget_FailingAsyncAction_LogsError()
+    {
+        // Arrange & Act
+        PttTaskExtensions.RunFireAndForget(
+            async () =>
+            {
+                await Task.Delay(10);
+                throw new InvalidOperationException("Async action failed");
+            },
+            _loggerMock.Object,
+            "FailingAsyncAction");
+
+        await Task.Delay(100);
+
+        // Assert
+        _loggerMock.Verify(
+            l => l.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("FailingAsyncAction")),
+                It.IsAny<AggregateException>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+}

--- a/tests/PushToTalk.Core.Tests/PushToTalk.Core.Tests.csproj
+++ b/tests/PushToTalk.Core.Tests/PushToTalk.Core.Tests.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- Added `TaskExtensions.FireAndForget()` extension method for proper exception logging
- Added `TaskExtensions.RunFireAndForget()` static methods for Action and Func<Task>
- Updated 18 fire-and-forget instances across 6 files to use the new extension

## Changes
| File | Instances Updated |
|------|-------------------|
| DictationWorker.cs | 6 |
| DictationHub.cs | 4 |
| DictationService.cs | 3 |
| TrayIcon.cs | 2 |
| Program.cs (App) | 2 |
| MultiClickDetector.cs | 1 |

## Test plan
- [x] All 334 tests pass
- [x] 8 new unit tests for TaskExtensions
- [x] Build succeeds without errors

Fixes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)