### PR TITLE
Centralize port configuration with ServiceEndpoints (fixes #14)

### DIFF
--- a/src/PushToTalk.App/Program.cs
+++ b/src/PushToTalk.App/Program.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
 using Olbrasoft.PushToTalk.App;
 using Olbrasoft.PushToTalk.App.Hubs;
+using Olbrasoft.PushToTalk.Core.Configuration;
 using Olbrasoft.PushToTalk.Core.Extensions;
 using Olbrasoft.PushToTalk.TextInput;
 
@@ -32,7 +33,7 @@ var options = new DictationOptions();
 config.GetSection(DictationOptions.SectionName).Bind(options);
 
 // Get port from config or use default
-var webPort = config.GetValue<int>("WebServer:Port", 5050);
+var webPort = config.GetValue<int>("WebServer:Port", ServiceEndpoints.DefaultWebServerPort);
 
 // Setup logging
 using var loggerFactory = LoggerFactory.Create(builder =>

--- a/src/PushToTalk.App/Services/VirtualAssistantClient.cs
+++ b/src/PushToTalk.App/Services/VirtualAssistantClient.cs
@@ -2,6 +2,7 @@ using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Olbrasoft.PushToTalk.Core.Configuration;
 
 namespace Olbrasoft.PushToTalk.App.Services;
 
@@ -23,8 +24,12 @@ public class VirtualAssistantClient : IVirtualAssistantClient
     {
         _logger = logger;
         _httpClient = httpClient;
+
+        var endpoints = new ServiceEndpoints();
+        configuration.GetSection(ServiceEndpoints.SectionName).Bind(endpoints);
+
         _baseUrl = configuration.GetValue<string>("VirtualAssistant:BaseUrl")
-            ?? "http://localhost:5055";
+            ?? endpoints.VirtualAssistant;
         _timeoutSeconds = configuration.GetValue<int>("VirtualAssistant:TimeoutSeconds", 30);
     }
 

--- a/src/PushToTalk.Core/Configuration/ServiceEndpoints.cs
+++ b/src/PushToTalk.Core/Configuration/ServiceEndpoints.cs
@@ -1,0 +1,53 @@
+namespace Olbrasoft.PushToTalk.Core.Configuration;
+
+/// <summary>
+/// Configuration for service endpoints used across the application.
+/// Centralizes all URL/port configuration to avoid magic numbers in code.
+/// </summary>
+public class ServiceEndpoints
+{
+    /// <summary>
+    /// Configuration section name in appsettings.json.
+    /// </summary>
+    public const string SectionName = "ServiceEndpoints";
+
+    /// <summary>
+    /// Default port for the web server (API, SignalR, static files).
+    /// </summary>
+    public const int DefaultWebServerPort = 5050;
+
+    /// <summary>
+    /// Default port for EdgeTTS service.
+    /// </summary>
+    public const int DefaultEdgeTtsPort = 5555;
+
+    /// <summary>
+    /// Default port for VirtualAssistant service.
+    /// </summary>
+    public const int DefaultVirtualAssistantPort = 5055;
+
+    /// <summary>
+    /// Default port for logs viewer service.
+    /// </summary>
+    public const int DefaultLogsViewerPort = 5052;
+
+    /// <summary>
+    /// URL for EdgeTTS service.
+    /// </summary>
+    public string EdgeTts { get; set; } = $"http://localhost:{DefaultEdgeTtsPort}";
+
+    /// <summary>
+    /// URL for VirtualAssistant service.
+    /// </summary>
+    public string VirtualAssistant { get; set; } = $"http://localhost:{DefaultVirtualAssistantPort}";
+
+    /// <summary>
+    /// URL for logs viewer service.
+    /// </summary>
+    public string LogsViewer { get; set; } = $"http://127.0.0.1:{DefaultLogsViewerPort}";
+
+    /// <summary>
+    /// Port for the web server.
+    /// </summary>
+    public int WebServerPort { get; set; } = DefaultWebServerPort;
+}

--- a/src/PushToTalk.Service/Program.cs
+++ b/src/PushToTalk.Service/Program.cs
@@ -1,5 +1,6 @@
 using Olbrasoft.PushToTalk;
 using Olbrasoft.PushToTalk.Audio;
+using Olbrasoft.PushToTalk.Core.Configuration;
 using Olbrasoft.PushToTalk.Service;
 using Olbrasoft.PushToTalk.Service.Services;
 using Olbrasoft.PushToTalk.Service.Tray;
@@ -48,7 +49,10 @@ app.MapPushToTalkEndpoints();
 var pttNotifier = app.Services.GetRequiredService<IPttNotifier>();
 var trayLogger = app.Services.GetRequiredService<ILogger<TranscriptionTrayService>>();
 var typingSoundPlayer = app.Services.GetRequiredService<TypingSoundPlayer>();
-var trayService = new TranscriptionTrayService(trayLogger, pttNotifier, typingSoundPlayer);
+var trayService = new TranscriptionTrayService(trayLogger, pttNotifier, typingSoundPlayer, builder.Configuration);
+
+// Get web server port from configuration
+var webPort = builder.Configuration.GetValue<int>("WebServer:Port", ServiceEndpoints.DefaultWebServerPort);
 
 try
 {
@@ -64,7 +68,7 @@ try
     Console.WriteLine("╚══════════════════════════════════════════════════════════════╝");
     Console.WriteLine();
     Console.WriteLine("Transcription tray icon initialized");
-    Console.WriteLine("API listening on http://localhost:5050");
+    Console.WriteLine($"API listening on http://localhost:{webPort}");
 
     // Start WebApplication in background
     var hostTask = Task.Run(async () =>

--- a/src/PushToTalk.Service/Services/TtsControlService.cs
+++ b/src/PushToTalk.Service/Services/TtsControlService.cs
@@ -2,12 +2,13 @@ using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Olbrasoft.PushToTalk.Core.Configuration;
 
 namespace Olbrasoft.PushToTalk.Service.Services;
 
 /// <summary>
 /// HTTP-based TTS control service implementation.
-/// Communicates with EdgeTTS (port 5555) and VirtualAssistant (port 5055) services.
+/// Communicates with EdgeTTS and VirtualAssistant services.
 /// </summary>
 public class TtsControlService : ITtsControlService
 {
@@ -30,10 +31,13 @@ public class TtsControlService : ITtsControlService
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
 
+        var endpoints = new ServiceEndpoints();
+        configuration?.GetSection(ServiceEndpoints.SectionName).Bind(endpoints);
+
         _edgeTtsBaseUrl = configuration?.GetValue<string>("EdgeTts:BaseUrl")
-            ?? "http://localhost:5555";
+            ?? endpoints.EdgeTts;
         _virtualAssistantBaseUrl = configuration?.GetValue<string>("VirtualAssistant:BaseUrl")
-            ?? "http://localhost:5055";
+            ?? endpoints.VirtualAssistant;
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
## Summary
- Added `ServiceEndpoints` class with default port constants and configurable URLs
- All port numbers now defined in one centralized location
- Services can be configured via `ServiceEndpoints` section in appsettings.json

## Default Ports
| Service | Port |
|---------|------|
| Web Server | 5050 |
| EdgeTTS | 5555 |
| VirtualAssistant | 5055 |
| Logs Viewer | 5052 |

## Files Changed
- `ServiceEndpoints.cs` (new) - Centralized configuration class
- `TtsControlService.cs` - Uses ServiceEndpoints defaults
- `TranscriptionTrayService.cs` - Configurable logs viewer URL
- `VirtualAssistantClient.cs` - Uses ServiceEndpoints defaults
- `Program.cs` (App) - Uses ServiceEndpoints.DefaultWebServerPort
- `Program.cs` (Service) - Uses configurable web port

## Test plan
- [x] All 334 tests pass
- [x] Build succeeds without errors

Fixes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)