### PR TITLE
Refactor DictationService: extract ITranscriptionCoordinator and ITextOutputHandler (fixes #11)

### DIFF
--- a/src/PushToTalk.App/DictationService.cs
+++ b/src/PushToTalk.App/DictationService.cs
@@ -2,8 +2,7 @@ using Microsoft.Extensions.Logging;
 using Olbrasoft.PushToTalk.App.Services;
 using Olbrasoft.PushToTalk.Audio;
 using Olbrasoft.PushToTalk.Core.Extensions;
-using Olbrasoft.PushToTalk.Speech;
-using Olbrasoft.PushToTalk.TextInput;
+using Olbrasoft.PushToTalk.Core.Interfaces;
 
 namespace Olbrasoft.PushToTalk.App;
 
@@ -18,7 +17,8 @@ public enum DictationState
 }
 
 /// <summary>
-/// Orchestrates the dictation workflow: recording, transcription, and text typing.
+/// Orchestrates the dictation workflow: recording, transcription, and text output.
+/// Refactored to use ITranscriptionCoordinator and ITextOutputHandler for SRP compliance.
 /// </summary>
 public class DictationService : IDisposable, IAsyncDisposable
 {
@@ -26,10 +26,8 @@ public class DictationService : IDisposable, IAsyncDisposable
     private readonly ILogger<DictationService> _logger;
     private readonly IKeyboardMonitor _keyboardMonitor;
     private readonly IAudioRecorder _audioRecorder;
-    private readonly ISpeechTranscriber _speechTranscriber;
-    private readonly ITextTyper _textTyper;
-    private readonly TypingSoundPlayer? _typingSoundPlayer;
-    private readonly TextFilter? _textFilter;
+    private readonly ITranscriptionCoordinator _transcriptionCoordinator;
+    private readonly ITextOutputHandler _textOutputHandler;
     private readonly IVirtualAssistantClient? _virtualAssistantClient;
     private readonly KeyCode _triggerKey;
     private readonly KeyCode _cancelKey;
@@ -58,21 +56,17 @@ public class DictationService : IDisposable, IAsyncDisposable
         ILogger<DictationService> logger,
         IKeyboardMonitor keyboardMonitor,
         IAudioRecorder audioRecorder,
-        ISpeechTranscriber speechTranscriber,
-        ITextTyper textTyper,
-        TypingSoundPlayer? typingSoundPlayer = null,
-        TextFilter? textFilter = null,
+        ITranscriptionCoordinator transcriptionCoordinator,
+        ITextOutputHandler textOutputHandler,
         IVirtualAssistantClient? virtualAssistantClient = null,
         KeyCode triggerKey = KeyCode.CapsLock,
         KeyCode cancelKey = KeyCode.Escape)
     {
-        _logger = logger;
-        _keyboardMonitor = keyboardMonitor;
-        _audioRecorder = audioRecorder;
-        _speechTranscriber = speechTranscriber;
-        _textTyper = textTyper;
-        _typingSoundPlayer = typingSoundPlayer;
-        _textFilter = textFilter;
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _keyboardMonitor = keyboardMonitor ?? throw new ArgumentNullException(nameof(keyboardMonitor));
+        _audioRecorder = audioRecorder ?? throw new ArgumentNullException(nameof(audioRecorder));
+        _transcriptionCoordinator = transcriptionCoordinator ?? throw new ArgumentNullException(nameof(transcriptionCoordinator));
+        _textOutputHandler = textOutputHandler ?? throw new ArgumentNullException(nameof(textOutputHandler));
         _virtualAssistantClient = virtualAssistantClient;
         _triggerKey = triggerKey;
         _cancelKey = cancelKey;
@@ -83,8 +77,8 @@ public class DictationService : IDisposable, IAsyncDisposable
     /// </summary>
     public async Task StartMonitoringAsync(CancellationToken cancellationToken)
     {
-        _logger.LogDebug("DictationService initialized - TriggerKey: {TriggerKey}, CancelKey: {CancelKey}, TextFilter: {HasFilter}, SoundPlayer: {HasSound}",
-            _triggerKey, _cancelKey, _textFilter != null, _typingSoundPlayer != null);
+        _logger.LogDebug("DictationService initialized - TriggerKey: {TriggerKey}, CancelKey: {CancelKey}",
+            _triggerKey, _cancelKey);
 
         _keyboardMonitor.KeyReleased += OnKeyReleased;
 
@@ -204,7 +198,7 @@ public class DictationService : IDisposable, IAsyncDisposable
     }
 
     /// <summary>
-    /// Stops recording, transcribes, and types the result.
+    /// Stops recording, transcribes, and outputs the result.
     /// </summary>
     public async Task StopDictationAsync()
     {
@@ -244,8 +238,6 @@ public class DictationService : IDisposable, IAsyncDisposable
                 return;
             }
 
-            // State is already Transcribing and CTS is ready (set in lock above)
-
             // Check for cancellation before starting transcription
             // This gives user time to cancel while recording was stopping
             if (_transcriptionCts.Token.IsCancellationRequested)
@@ -254,37 +246,22 @@ public class DictationService : IDisposable, IAsyncDisposable
                 throw new OperationCanceledException(_transcriptionCts.Token);
             }
 
-            // Start transcription sound loop
-            _typingSoundPlayer?.StartLoop();
-
-            // One more check right before transcription
-            _transcriptionCts.Token.ThrowIfCancellationRequested();
-
-            _logger.LogInformation("Starting transcription...");
-            var result = await _speechTranscriber.TranscribeAsync(audioData, _transcriptionCts.Token);
-
-            // Stop transcription sound loop
-            _typingSoundPlayer?.StopLoop();
+            // Transcribe with feedback (sound loop handled by coordinator)
+            var result = await _transcriptionCoordinator.TranscribeWithFeedbackAsync(
+                audioData,
+                _transcriptionCts.Token);
 
             if (result.Success && !string.IsNullOrWhiteSpace(result.Text))
             {
                 _logger.LogInformation("Transcription: {Text}", result.Text);
 
-                // Apply text filters
-                var filteredText = _textFilter?.Apply(result.Text) ?? result.Text;
+                // Output text (filtering + typing handled by handler)
+                var typedText = await _textOutputHandler.OutputTextAsync(result.Text);
 
-                if (!string.IsNullOrWhiteSpace(filteredText))
+                if (typedText != null)
                 {
-                    // Type the transcribed text
-                    await _textTyper.TypeTextAsync(filteredText);
-                    _logger.LogInformation("Text typed successfully");
-
                     // Notify listeners about transcription completion
-                    TranscriptionCompleted?.Invoke(this, filteredText);
-                }
-                else
-                {
-                    _logger.LogInformation("Text empty after filtering, nothing to type");
+                    TranscriptionCompleted?.Invoke(this, typedText);
                 }
             }
             else
@@ -302,8 +279,6 @@ public class DictationService : IDisposable, IAsyncDisposable
         }
         finally
         {
-            // Ensure sound is stopped even on error/cancel
-            _typingSoundPlayer?.StopLoop();
             _transcriptionCts?.Dispose();
             _transcriptionCts = null;
             _cts?.Dispose();
@@ -331,8 +306,7 @@ public class DictationService : IDisposable, IAsyncDisposable
         _keyboardMonitor.KeyReleased -= OnKeyReleased;
         _cts?.Cancel();
         _cts?.Dispose();
-        _typingSoundPlayer?.Dispose();
-        _speechTranscriber.Dispose();
+        _transcriptionCoordinator.Dispose();
 
         GC.SuppressFinalize(this);
     }
@@ -350,8 +324,7 @@ public class DictationService : IDisposable, IAsyncDisposable
 
         _cts?.Cancel();
         _cts?.Dispose();
-        _typingSoundPlayer?.Dispose();
-        _speechTranscriber.Dispose();
+        _transcriptionCoordinator.Dispose();
 
         GC.SuppressFinalize(this);
     }

--- a/src/PushToTalk.App/Services/ITextOutputHandler.cs
+++ b/src/PushToTalk.App/Services/ITextOutputHandler.cs
@@ -1,0 +1,15 @@
+namespace Olbrasoft.PushToTalk.App.Services;
+
+/// <summary>
+/// Handles text output: filtering and typing.
+/// Combines text filtering and text typing into a single abstraction.
+/// </summary>
+public interface ITextOutputHandler
+{
+    /// <summary>
+    /// Processes and outputs the text: applies filters and types the result.
+    /// </summary>
+    /// <param name="text">The text to process and output.</param>
+    /// <returns>The filtered text that was typed, or null if nothing was typed.</returns>
+    Task<string?> OutputTextAsync(string text);
+}

--- a/src/PushToTalk.App/Services/ITranscriptionCoordinator.cs
+++ b/src/PushToTalk.App/Services/ITranscriptionCoordinator.cs
@@ -1,0 +1,17 @@
+using Olbrasoft.PushToTalk.Core.Models;
+
+namespace Olbrasoft.PushToTalk.App.Services;
+
+/// <summary>
+/// Coordinates the transcription workflow: speech transcription with sound feedback.
+/// </summary>
+public interface ITranscriptionCoordinator : IDisposable
+{
+    /// <summary>
+    /// Transcribes audio data with sound feedback during processing.
+    /// </summary>
+    /// <param name="audioData">Audio data to transcribe.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Transcription result.</returns>
+    Task<TranscriptionResult> TranscribeWithFeedbackAsync(byte[] audioData, CancellationToken cancellationToken = default);
+}

--- a/src/PushToTalk.App/Services/TextOutputHandler.cs
+++ b/src/PushToTalk.App/Services/TextOutputHandler.cs
@@ -1,0 +1,49 @@
+using Microsoft.Extensions.Logging;
+using Olbrasoft.PushToTalk.TextInput;
+
+namespace Olbrasoft.PushToTalk.App.Services;
+
+/// <summary>
+/// Handles text output: applies filters and types the result.
+/// </summary>
+public class TextOutputHandler : ITextOutputHandler
+{
+    private readonly ILogger<TextOutputHandler> _logger;
+    private readonly ITextTyper _textTyper;
+    private readonly TextFilter? _textFilter;
+
+    public TextOutputHandler(
+        ILogger<TextOutputHandler> logger,
+        ITextTyper textTyper,
+        TextFilter? textFilter = null)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _textTyper = textTyper ?? throw new ArgumentNullException(nameof(textTyper));
+        _textFilter = textFilter;
+    }
+
+    /// <inheritdoc />
+    public async Task<string?> OutputTextAsync(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            _logger.LogDebug("No text to output");
+            return null;
+        }
+
+        // Apply text filters
+        var filteredText = _textFilter?.Apply(text) ?? text;
+
+        if (string.IsNullOrWhiteSpace(filteredText))
+        {
+            _logger.LogInformation("Text empty after filtering, nothing to type");
+            return null;
+        }
+
+        // Type the filtered text
+        await _textTyper.TypeTextAsync(filteredText);
+        _logger.LogInformation("Text typed successfully: {CharCount} characters", filteredText.Length);
+
+        return filteredText;
+    }
+}

--- a/src/PushToTalk.App/Services/TranscriptionCoordinator.cs
+++ b/src/PushToTalk.App/Services/TranscriptionCoordinator.cs
@@ -1,0 +1,66 @@
+using Microsoft.Extensions.Logging;
+using Olbrasoft.PushToTalk.Audio;
+using Olbrasoft.PushToTalk.Core.Models;
+using Olbrasoft.PushToTalk.Speech;
+
+namespace Olbrasoft.PushToTalk.App.Services;
+
+/// <summary>
+/// Coordinates transcription with audio feedback (typing sound loop).
+/// </summary>
+public class TranscriptionCoordinator : ITranscriptionCoordinator
+{
+    private readonly ILogger<TranscriptionCoordinator> _logger;
+    private readonly ISpeechTranscriber _speechTranscriber;
+    private readonly TypingSoundPlayer? _typingSoundPlayer;
+    private bool _disposed;
+
+    public TranscriptionCoordinator(
+        ILogger<TranscriptionCoordinator> logger,
+        ISpeechTranscriber speechTranscriber,
+        TypingSoundPlayer? typingSoundPlayer = null)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _speechTranscriber = speechTranscriber ?? throw new ArgumentNullException(nameof(speechTranscriber));
+        _typingSoundPlayer = typingSoundPlayer;
+    }
+
+    /// <inheritdoc />
+    public async Task<TranscriptionResult> TranscribeWithFeedbackAsync(
+        byte[] audioData,
+        CancellationToken cancellationToken = default)
+    {
+        if (audioData == null || audioData.Length == 0)
+        {
+            return new TranscriptionResult("No audio data provided");
+        }
+
+        try
+        {
+            // Start transcription sound loop
+            _typingSoundPlayer?.StartLoop();
+
+            _logger.LogInformation("Starting transcription of {ByteCount} bytes...", audioData.Length);
+            var result = await _speechTranscriber.TranscribeAsync(audioData, cancellationToken);
+
+            return result;
+        }
+        finally
+        {
+            // Always stop sound loop
+            _typingSoundPlayer?.StopLoop();
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+        _typingSoundPlayer?.Dispose();
+        _speechTranscriber.Dispose();
+
+        GC.SuppressFinalize(this);
+    }
+}


### PR DESCRIPTION
## Summary
- Extract `ITranscriptionCoordinator` interface for speech transcription + sound feedback
- Extract `ITextOutputHandler` interface for text filtering + typing
- Reduce `DictationService` constructor from 10 to 8 parameters (6 required + 2 optional)
- Create implementations: `TranscriptionCoordinator` and `TextOutputHandler`
- Update DI registrations in `ServiceCollectionExtensions`
- Update tests to use new abstractions

## Changes
- `src/PushToTalk.App/Services/ITranscriptionCoordinator.cs` - new interface
- `src/PushToTalk.App/Services/TranscriptionCoordinator.cs` - implementation
- `src/PushToTalk.App/Services/ITextOutputHandler.cs` - new interface
- `src/PushToTalk.App/Services/TextOutputHandler.cs` - implementation
- `src/PushToTalk.App/DictationService.cs` - simplified constructor
- `src/PushToTalk.App/ServiceCollectionExtensions.cs` - updated DI
- `tests/PushToTalk.App.Tests/DictationServiceTests.cs` - updated tests

## Test plan
- [x] All 334 unit tests pass
- [x] Build succeeds without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)