### PR TITLE
Change tray icon to white immediately when recording stops

### DIFF
--- a/src/PushToTalk.App/Program.cs
+++ b/src/PushToTalk.App/Program.cs
@@ -223,6 +223,8 @@ try
                     dbusTrayIcon.SetTooltip("Push To Talk - Recording...");
                     break;
                 case DictationState.Transcribing:
+                    // Change icon back to white immediately when recording stops (issue #28)
+                    dbusTrayIcon.SetIcon("trigger-ptt");
                     dbusTrayIcon.SetTooltip("Push To Talk - Transcribing...");
                     // Show animated icon NEXT TO main icon (main stays visible)
                     await animatedIcon.ShowAsync();


### PR DESCRIPTION
## Summary

- Change tray icon from orange to white immediately when CapsLock is released
- Icon changes when state transitions to Transcribing, not when transcription completes

## Changes

Added `dbusTrayIcon.SetIcon("trigger-ptt")` in the Transcribing state handler.

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)