### PR TITLE
Consolidate audio CLI tools to pw-cat (PipeWire)

### DIFF
--- a/src/PushToTalk.App/ServiceCollectionExtensions.cs
+++ b/src/PushToTalk.App/ServiceCollectionExtensions.cs
@@ -40,8 +40,8 @@ public static class ServiceCollectionExtensions
         // Audio recorder
         services.AddSingleton<IAudioRecorder>(sp =>
         {
-            var logger = sp.GetRequiredService<ILogger<AlsaAudioRecorder>>();
-            return new AlsaAudioRecorder(logger);
+            var logger = sp.GetRequiredService<ILogger<PipeWireAudioRecorder>>();
+            return new PipeWireAudioRecorder(logger);
         });
 
         // Speech transcriber

--- a/src/PushToTalk.Linux/Audio/TypingSoundPlayer.cs
+++ b/src/PushToTalk.Linux/Audio/TypingSoundPlayer.cs
@@ -5,7 +5,7 @@ namespace Olbrasoft.PushToTalk.Audio;
 
 /// <summary>
 /// Service for playing typing sound during transcription.
-/// Uses pw-play (PipeWire) or paplay (PulseAudio) to play audio.
+/// Uses pw-cat (PipeWire) or paplay (PulseAudio) to play audio.
 /// </summary>
 public class TypingSoundPlayer : IDisposable
 {
@@ -217,7 +217,7 @@ public class TypingSoundPlayer : IDisposable
 
         if (string.IsNullOrEmpty(player))
         {
-            _logger.LogWarning("No audio player available (tried pw-play, paplay)");
+            _logger.LogWarning("No audio player available (tried pw-cat, paplay)");
             return;
         }
 
@@ -262,14 +262,14 @@ public class TypingSoundPlayer : IDisposable
         if (_cachedPlayer != null)
             return _cachedPlayer;
 
-        // Check for pw-play (PipeWire)
-        if (await IsCommandAvailableAsync("pw-play"))
+        // Check for pw-cat (PipeWire) - pw-play is just a symlink to pw-cat
+        if (await IsCommandAvailableAsync("pw-cat"))
         {
-            _cachedPlayer = "pw-play";
+            _cachedPlayer = "pw-cat";
             return _cachedPlayer;
         }
 
-        // Check for paplay (PulseAudio)
+        // Fallback to paplay (PulseAudio) for systems without PipeWire
         if (await IsCommandAvailableAsync("paplay"))
         {
             _cachedPlayer = "paplay";

--- a/src/PushToTalk.Service/ServiceCollectionExtensions.cs
+++ b/src/PushToTalk.Service/ServiceCollectionExtensions.cs
@@ -68,8 +68,8 @@ public static class ServiceCollectionExtensions
 
         services.AddSingleton<IAudioRecorder>(sp =>
         {
-            var logger = sp.GetRequiredService<ILogger<AlsaAudioRecorder>>();
-            return new AlsaAudioRecorder(logger);
+            var logger = sp.GetRequiredService<ILogger<PipeWireAudioRecorder>>();
+            return new PipeWireAudioRecorder(logger);
         });
 
         services.AddSingleton<ISpeechTranscriber>(sp =>


### PR DESCRIPTION
## Summary

Consolidate multiple CLI audio tools to single `pw-cat` (PipeWire).

### Issue #25: Update TypingSoundPlayer
- Changed from `pw-play` to `pw-cat` (pw-play is just a symlink)
- Updated comments and warning messages

### Issue #26: Rename AlsaAudioRecorder
- Renamed class to `PipeWireAudioRecorder`
- Moved to `Audio/` directory
- Changed from `pw-record` to `pw-cat -r`
- Updated DI registrations

## Why pw-cat?

| Tool | X11 | Wayland | TTY | Mechanism |
|------|-----|---------|-----|-----------|
| **pw-cat** | ✅ | ✅ | ✅ | PipeWire (default on modern distros) |
| ~~pw-play~~ | symlink to pw-cat | | | |
| ~~pw-record~~ | symlink to pw-cat | | | |

Fallback to `paplay`/`arecord` preserved for systems without PipeWire.

## Test plan

- [x] `dotnet build` succeeds
- [x] `dotnet test` passes (353 tests)
- [ ] Manual test: Audio playback works
- [ ] Manual test: Audio recording works

Closes #24, closes #25, closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)