### PR TITLE
Move hardcoded configuration to appsettings.json (#43)

### DIFF
--- a/src/PushToTalk.App/Configuration/ConfigurationValidator.cs
+++ b/src/PushToTalk.App/Configuration/ConfigurationValidator.cs
@@ -1,0 +1,47 @@
+namespace Olbrasoft.PushToTalk.App.Configuration;
+
+/// <summary>
+/// Validates configuration options on application startup.
+/// </summary>
+public static class ConfigurationValidator
+{
+    /// <summary>
+    /// Validates web server configuration.
+    /// </summary>
+    public static void ValidateWebServerOptions(WebServerOptions options)
+    {
+        if (options.Port <= 0 || options.Port > 65535)
+        {
+            throw new InvalidOperationException($"Invalid HTTP port: {options.Port}. Must be between 1 and 65535.");
+        }
+
+        if (options.Https != null)
+        {
+            if (options.Https.Port <= 0 || options.Https.Port > 65535)
+            {
+                throw new InvalidOperationException($"Invalid HTTPS port: {options.Https.Port}. Must be between 1 and 65535.");
+            }
+
+            if (string.IsNullOrWhiteSpace(options.Https.CertificatePath))
+            {
+                throw new InvalidOperationException("HTTPS certificate path cannot be empty.");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Validates tray icon configuration.
+    /// </summary>
+    public static void ValidateTrayIconOptions(TrayIconOptions options)
+    {
+        if (options.Animation.Frames == null || options.Animation.Frames.Length == 0)
+        {
+            throw new InvalidOperationException("Animation frames cannot be empty.");
+        }
+
+        if (options.Animation.IntervalMs <= 0)
+        {
+            throw new InvalidOperationException($"Invalid animation interval: {options.Animation.IntervalMs}ms. Must be greater than 0.");
+        }
+    }
+}

--- a/src/PushToTalk.App/Configuration/TrayIconOptions.cs
+++ b/src/PushToTalk.App/Configuration/TrayIconOptions.cs
@@ -1,0 +1,35 @@
+namespace Olbrasoft.PushToTalk.App.Configuration;
+
+/// <summary>
+/// Configuration options for the system tray icon.
+/// </summary>
+public class TrayIconOptions
+{
+    /// <summary>
+    /// Animation configuration for the tray icon.
+    /// </summary>
+    public AnimationOptions Animation { get; set; } = new();
+}
+
+/// <summary>
+/// Animation configuration for the tray icon.
+/// </summary>
+public class AnimationOptions
+{
+    /// <summary>
+    /// List of animation frame filenames (without path).
+    /// </summary>
+    public string[] Frames { get; set; } = new[]
+    {
+        "document-white-frame1.svg",
+        "document-white-frame2.svg",
+        "document-white-frame3.svg",
+        "document-white-frame4.svg",
+        "document-white-frame5.svg"
+    };
+
+    /// <summary>
+    /// Animation interval in milliseconds.
+    /// </summary>
+    public int IntervalMs { get; set; } = 150;
+}

--- a/src/PushToTalk.App/Configuration/WebServerOptions.cs
+++ b/src/PushToTalk.App/Configuration/WebServerOptions.cs
@@ -1,0 +1,38 @@
+namespace Olbrasoft.PushToTalk.App.Configuration;
+
+/// <summary>
+/// Configuration options for the web server (Kestrel).
+/// </summary>
+public class WebServerOptions
+{
+    /// <summary>
+    /// HTTP port for the web server.
+    /// </summary>
+    public int Port { get; set; } = 5050;
+
+    /// <summary>
+    /// HTTPS configuration (optional).
+    /// </summary>
+    public HttpsOptions? Https { get; set; }
+}
+
+/// <summary>
+/// HTTPS configuration for the web server.
+/// </summary>
+public class HttpsOptions
+{
+    /// <summary>
+    /// HTTPS port for the web server.
+    /// </summary>
+    public int Port { get; set; } = 5051;
+
+    /// <summary>
+    /// Path to the SSL certificate (relative to app directory or absolute).
+    /// </summary>
+    public string CertificatePath { get; set; } = "certs/localhost.p12";
+
+    /// <summary>
+    /// Password for the SSL certificate.
+    /// </summary>
+    public string CertificatePassword { get; set; } = "changeit";
+}

--- a/src/PushToTalk.App/ServiceCollectionExtensions.cs
+++ b/src/PushToTalk.App/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Olbrasoft.PushToTalk.App.Configuration;
 using Olbrasoft.PushToTalk.App.Services;
 using Olbrasoft.PushToTalk.App.Tray;
 using Olbrasoft.PushToTalk.Audio;
@@ -152,7 +153,8 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddTrayServices(
         this IServiceCollection services,
         DictationOptions options,
-        string iconsPath)
+        string iconsPath,
+        TrayIconOptions trayIconOptions)
     {
         // SpeechToText service manager for status checking and control
         services.AddSingleton<SpeechToTextServiceManager>();
@@ -186,7 +188,7 @@ public static class ServiceCollectionExtensions
             var logger = sp.GetRequiredService<ILogger<PushToTalkTrayService>>();
             var manager = sp.GetRequiredService<TrayIconManager>();
             var menuHandler = sp.GetRequiredService<ITrayMenuHandler>();
-            return new PushToTalkTrayService(logger, manager, iconsPath, menuHandler);
+            return new PushToTalkTrayService(logger, manager, iconsPath, trayIconOptions, menuHandler);
         });
 
         return services;

--- a/src/PushToTalk.App/Tray/PushToTalkTrayService.cs
+++ b/src/PushToTalk.App/Tray/PushToTalkTrayService.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using Olbrasoft.PushToTalk.App.Configuration;
 using Olbrasoft.SystemTray.Linux;
 
 namespace Olbrasoft.PushToTalk.App.Tray;
@@ -13,6 +14,7 @@ public class PushToTalkTrayService : IDisposable
     private readonly ILogger<PushToTalkTrayService> _logger;
     private readonly string _iconsPath;
     private readonly string[] _animationFrames;
+    private readonly int _animationIntervalMs;
     private readonly ITrayMenuHandler? _menuHandler;
 
     private ITrayIcon? _mainIcon;
@@ -33,21 +35,18 @@ public class PushToTalkTrayService : IDisposable
         ILogger<PushToTalkTrayService> logger,
         TrayIconManager manager,
         string iconsPath,
+        TrayIconOptions trayIconOptions,
         ITrayMenuHandler? menuHandler = null)
     {
         _logger = logger;
         _manager = manager;
         _iconsPath = iconsPath;
         _menuHandler = menuHandler;
+        _animationIntervalMs = trayIconOptions.Animation.IntervalMs;
 
-        _animationFrames = new[]
-        {
-            Path.Combine(iconsPath, "document-white-frame1.svg"),
-            Path.Combine(iconsPath, "document-white-frame2.svg"),
-            Path.Combine(iconsPath, "document-white-frame3.svg"),
-            Path.Combine(iconsPath, "document-white-frame4.svg"),
-            Path.Combine(iconsPath, "document-white-frame5.svg")
-        };
+        _animationFrames = trayIconOptions.Animation.Frames
+            .Select(frame => Path.Combine(iconsPath, frame))
+            .ToArray();
 
         // Connect menu handler events to our events
         if (_menuHandler is DBusMenuHandler dbusMenuHandler)
@@ -110,7 +109,7 @@ public class PushToTalkTrayService : IDisposable
 
             if (_animatedIcon != null)
             {
-                _animatedIcon.StartAnimation(_animationFrames, intervalMs: 150);
+                _animatedIcon.StartAnimation(_animationFrames, intervalMs: _animationIntervalMs);
             }
         }
         catch (Exception ex)

--- a/src/PushToTalk.App/appsettings.json
+++ b/src/PushToTalk.App/appsettings.json
@@ -9,5 +9,25 @@
     "RecordingStartSoundPath": null,
     "ShowTranscriptionAnimation": true,
     "TextFiltersPath": "text-filters.json"
+  },
+  "WebServer": {
+    "Port": 5050,
+    "Https": {
+      "Port": 5051,
+      "CertificatePath": "certs/192.168.0.182+3.p12",
+      "CertificatePassword": "changeit"
+    }
+  },
+  "TrayIcon": {
+    "Animation": {
+      "Frames": [
+        "document-white-frame1.svg",
+        "document-white-frame2.svg",
+        "document-white-frame3.svg",
+        "document-white-frame4.svg",
+        "document-white-frame5.svg"
+      ],
+      "IntervalMs": 150
+    }
   }
 }


### PR DESCRIPTION
## Summary
Refactoring: Eliminates magic numbers and hardcoded configuration values by moving them to appsettings.json with proper Options pattern and validation.

## Changes
**New files:**
- `Configuration/WebServerOptions.cs` - HTTP/HTTPS port and certificate configuration
- `Configuration/TrayIconOptions.cs` - Tray icon animation configuration  
- `Configuration/ConfigurationValidator.cs` - Startup validation for configuration

**Modified files:**
- `appsettings.json` - Added WebServer and TrayIcon sections
- `Program.cs` - Loads configuration and uses WebServerOptions/TrayIconOptions
- `ServiceCollectionExtensions.cs` - Passes TrayIconOptions to tray services
- `Tray/PushToTalkTrayService.cs` - Accepts TrayIconOptions in constructor

**Configuration values moved from hardcode:**
- HTTP port: 5050
- HTTPS port: 5051  
- HTTPS certificate path: certs/192.168.0.182+3.p12
- HTTPS certificate password: changeit
- Animation frames: 5 SVG frame filenames
- Animation interval: 150ms

## Test plan
- [x] All 351 tests passed (Service: 104, Linux: 102, Core: 58, App: 87)
- [x] Build successful with 0 errors
- [x] Configuration properly loaded and validated on startup
- [x] Kestrel configured with ports from appsettings.json
- [x] Tray animation uses configured frames and interval

Fixes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)